### PR TITLE
Restore codelab buttons to landing page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (214)
@@ -213,6 +213,8 @@ GEM
     minitest (5.24.1)
     nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -254,6 +256,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   ffi (>= 1.9.24)

--- a/home.html
+++ b/home.html
@@ -11,7 +11,7 @@ redirect_from: /
 			An AI education platform for building games, programming robots &amp; training
 			AI models
 		</h1>
-		<!-- <div class="home__banner-buttons">
+		<div class="home__banner-buttons">
 			<a class="button--primary"
 				href="https://cognimate.me/home"
 				target="_blank">Train Models
@@ -20,7 +20,7 @@ redirect_from: /
 				href="https://hackidemia.github.io/cognimates-gui/"
 				target="_blank">Code &amp; Play
 			</a>
-		</div> -->
+		</div>
 	</div>
 
     <div class="panel panel--images ">


### PR DESCRIPTION
# Restore Codelab Buttons to Landing Page

This PR restores the previously commented out codelab buttons on the landing page, including both the 'Train Models' and 'Code & Play' buttons that were temporarily removed.

## Changes
- Uncommented the `home__banner-buttons` div in home.html
- Restored both the "Train Models" and "Code & Play" buttons
- Maintained all existing button URLs and styling

## Context
The buttons were temporarily commented out in commit a613c3670cb06233d26dbd77cfaac6c250dab21d and are now being restored as requested.

Link to Devin run: https://preview.devin.ai/devin/2a899569b1e64c84ad7c7bb4a77a0424
